### PR TITLE
DM-51236: Serve multiple data releases from crawlspace

### DIFF
--- a/technote.toml
+++ b/technote.toml
@@ -10,6 +10,9 @@ license.id = "CC-BY-4.0"
 [[technote.authors]]
 name = {given = "Russ", family = "Allbery"}
 internal_id = "allberyr"
+[[technote.authors]]
+name = {given = "Dan", family = "Fuchs"}
+internal_id = "fuchsds"
 [[technote.authors.affiliations]]
 name = "Vera C. Rubin Observatory Project Office"
 internal_id = "RubinObs"


### PR DESCRIPTION
Describe [new `/api/hips/v2/<release>` crawlspace endpoint](https://github.com/lsst-sqre/crawlspace/pull/90) for serving files from different data releases.